### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 grpcio==1.18.0
 grpcio-tools==1.18.0
 pyyaml
+cryptography


### PR DESCRIPTION
Adds missing entry in requirements.txt, fixes the following after a clean install

```
Traceback (most recent call last):
  File "/Users/omer.yampel/dev/velociraptor.py", line 5, in <module>
    from pyvelociraptor import api_pb2, api_pb2_grpc
  File "/Users/omer.yampel/.envs/foo-bDHTaLbI/lib/python3.8/site-packages/pyvelociraptor/__init__.py", line 1, in <module>
    from cryptography.hazmat.primitives import serialization
ModuleNotFoundError: No module named 'cryptography'
```