### PR TITLE
Artifact execution and collection, solution to JSON exception 

### DIFF
--- a/pyvelociraptor/velo_pandas.py
+++ b/pyvelociraptor/velo_pandas.py
@@ -114,8 +114,9 @@ def DataFrameQuery(query, timeout=600, config=None, **kw):
 
         result = {}
         for response in stub.Query(request):
-            for row in json.loads(response.Response):
-                for c in response.Columns:
-                    result.setdefault(c, []).append(row.get(c))
+            if response.Response:
+              for row in json.loads(response.Response):
+                  for c in response.Columns:
+                      result.setdefault(c, []).append(row.get(c))
 
         return result

--- a/pyvelociraptor/wrappers.py
+++ b/pyvelociraptor/wrappers.py
@@ -109,8 +109,12 @@ def run_artifact(hostname, artifact_name, config=None, artifact_parameters=None,
             client_id=CID, 
             flow_id=Flow_ID)"""
     if limit:
-        vql += f"\n\tLIMIT {limit}"
-        
+        try:
+            vql += f"\n\tLIMIT {int(limit)}"
+        except ValueError:
+            print("[-] Incorrect 'limit' value... Should be integer!")
+            return None
+
     if verbose:
         print(f"[!] Collecting data using following VQL:")
         print(vql.replace("Artifact_Name", f'"{artifact_collect_name}"')\

--- a/pyvelociraptor/wrappers.py
+++ b/pyvelociraptor/wrappers.py
@@ -1,0 +1,146 @@
+
+
+from velo_pandas import DataFrameQuery as run
+import pandas as pd
+import time
+
+pd.set_option('display.max_colwidth', None)
+pd.set_option('display.max_columns', None)
+pd.set_option('display.max_rows', None)
+
+# helper functions
+def getdf(vql):
+    return pd.DataFrame(run(vql))
+
+def getparams(d):
+    o = "dict("
+    for i,(k,v) in enumerate(d.items()):
+        if i == len(d) - 1: #LAST
+            o += k+'="'+v+'")'
+            return o
+        else:
+            o += k+'="'+v+'",'
+
+
+def run_artifact(hostname, artifact_name, artifact_parameters=None, limit=None, artifact_collect_name=None, verbose=True, timeout=600):
+    """
+    # [Instantiates artifact for specific hostname and returns it's results as a pandas DataFrame]
+    # Examples:
+
+    # >>> df = wrappers.run_artifact("MY_HOSTNAME", "Windows.System.Pslist")
+
+    # [+] Client ID found: C.869eb611eaa5b899
+    # [!] Running VQL:
+
+    #         SELECT collect_client(
+    #             client_id="C.869eb611eaa5b899", 
+    #             artifacts="Windows.System.Pslist") 
+    #         AS Flow FROM scope() 
+
+    # [+] Got artifact flow ID: F.BVSSIUHNPUV7E
+    # [!] Collecting data using following VQL:
+
+    #         SELECT * FROM source(
+    #             artifact='Windows.System.Pslist',
+    #             client_id="C.869eb611eaa5b899", flow_id='F.BVSSIUHNPUV7E') 
+
+    # [!] Artifact is running... 0s
+    # [!] Artifact is running... 5.3s
+    # [+] Done! 11.0s
+
+    # >>> wrappers.run_artifact("NON_EXISTENT_HOSTNAME", "Windows.System.Pslist")
+    # [-] Cannot find any Client ID by provided hostname.
+
+    # >>> wrappers.run_artifact("MY_HOSTNAME", "Windows.System.NonExist")
+    # [+] Client ID found: C.869eb611eaa5b899
+    # [!] Running VQL:
+
+    #         SELECT collect_client(
+    #             client_id="C.869eb611eaa5b899", 
+    #             artifacts="Windows.System.Pslist123") 
+    #         AS Flow FROM scope() 
+
+    # [-] Artifact not instantiated... Check name and parameters!
+
+    # Returns:
+    #     [pandas.DataFrane]: [Results of artifact execution.]
+    """    
+
+    # FINDING CLIENT_ID FROM HOSTNAME
+    cid_query = run(f"""
+    SELECT client_id FROM clients(search="{hostname}")
+    """)
+    if cid_query:
+        cid = cid_query["client_id"][0]
+        if verbose:
+            print(f"[+] Client ID found: {cid}")
+    else:
+        print("[-] Cannot find any Client ID by provided hostname.")
+        return None
+
+    # INSTANTIATING ARTIFACT
+    if artifact_parameters:
+        start_artifact = f"""
+        SELECT collect_client(
+            client_id="{cid}", 
+            artifacts="{artifact_name}", 
+            env={getparams(artifact_parameters)}) 
+        AS Flow FROM scope()"""
+    else:
+        start_artifact = f"""
+        SELECT collect_client(
+            client_id="{cid}", 
+            artifacts="{artifact_name}") 
+        AS Flow FROM scope()"""
+
+    if verbose:
+        print("[!] Running VQL:")
+        print(start_artifact,"\n")
+    
+    # GETTING RESPONSE METADATA
+    meta = run(start_artifact)
+    if not meta["Flow"][0]:
+        print("[-] Artifact not instantiated... Check name and parameters!")
+        return None
+    
+    flow_id = meta["Flow"][0]["flow_id"]
+    if verbose:
+        print(f"[+] Got artifact flow ID: {flow_id}")
+
+    # GETTING RESPONSE ACTUAL DATA
+    response_df = pd.DataFrame()
+    if not artifact_collect_name:
+        artifact_collect_name = artifact_name
+    if limit:
+        vql = f"""
+        SELECT * FROM source(
+            artifact='{artifact_collect_name}',
+            client_id="{cid}", flow_id='{flow_id}')
+        LIMIT {limit}"""
+    else:
+        vql = f"""
+        SELECT * FROM source(
+            artifact='{artifact_collect_name}',
+            client_id="{cid}", flow_id='{flow_id}')"""
+    if verbose:
+        print(f"[!] Collecting data using following VQL:")
+        print(vql,"\n")
+
+    now = time.time()
+    delay = 0
+    while response_df.empty and delay < timeout:
+        if verbose:
+            print(f"[!] Artifact is running... {round(delay,2)}s")
+    
+        response_df = getdf(vql)
+        
+        time.sleep(5)
+        delay = time.time() - now
+    
+    if verbose:
+        if delay < timeout:
+            print(f"[+] Done! {round(delay,2)}s\n")
+        else:
+            print(f"[-] Reached timeout ({timeout}s)... Check artifact status manually in Velociraptor GUI.\n")
+    
+    return response_df

--- a/pyvelociraptor/wrappers.py
+++ b/pyvelociraptor/wrappers.py
@@ -102,7 +102,8 @@ def run_artifact(hostname, artifact_name, config=None, artifact_parameters=None,
     vql = f"""
         SELECT * FROM source(
             artifact='{artifact_collect_name}',
-            client_id="{cid}", flow_id='{flow_id}')"""
+            client_id="{cid}", 
+            flow_id='{flow_id}')"""
     if limit:
         vql += f"\n\tLIMIT {limit}"
         

--- a/pyvelociraptor/wrappers.py
+++ b/pyvelociraptor/wrappers.py
@@ -99,17 +99,13 @@ def run_artifact(hostname, artifact_name, config=None, artifact_parameters=None,
     response_df = pd.DataFrame()
     if not artifact_collect_name:
         artifact_collect_name = artifact_name
-    if limit:
-        vql = f"""
-        SELECT * FROM source(
-            artifact='{artifact_collect_name}',
-            client_id="{cid}", flow_id='{flow_id}')
-        LIMIT {limit}"""
-    else:
-        vql = f"""
+    vql = f"""
         SELECT * FROM source(
             artifact='{artifact_collect_name}',
             client_id="{cid}", flow_id='{flow_id}')"""
+    if limit:
+        vql += f"\n\tLIMIT {limit}"
+        
     if verbose:
         print(f"[!] Collecting data using following VQL:")
         print(vql,"\n")


### PR DESCRIPTION
One commit - solves JSON exception in `velo_pandas.DataFrameQuery`:

```
---------------------------------------------------------------------------
JSONDecodeError                           Traceback (most recent call last)
<ipython-input-35-f34fcd9b37d8> in <module>
----> 1 vp.DataFrameQuery(vql)

/usr/local/lib/python3.9/site-packages/pyvelociraptor/velo_pandas.py in DataFrameQuery(query, timeout, config, **kw)
    115         result = {}
    116         for response in stub.Query(request):
--> 117             for row in json.loads(response.Response):
    118                 for c in response.Columns:

/usr/local/Cellar/python@3.9/3.9.0_5/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/__init__.py in loads(s, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
    344             parse_int is None and parse_float is None and
    345             parse_constant is None and object_pairs_hook is None and not kw):
--> 346         return _default_decoder.decode(s)
    347     if cls is None:
    348         cls = JSONDecoder

/usr/local/Cellar/python@3.9/3.9.0_5/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/decoder.py in decode(self, s, _w)
    335 
    336         """
--> 337         obj, end = self.raw_decode(s, idx=_w(s, 0).end())
    338         end = _w(s, end).end()
    339         if end != len(s):

/usr/local/Cellar/python@3.9/3.9.0_5/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/decoder.py in raw_decode(self, s, idx)
    353             obj, end = self.scan_once(s, idx)
    354         except StopIteration as err:
--> 355             raise JSONDecodeError("Expecting value", s, err.value) from None
    356         return obj, end

JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Problem was that not all response objects in `stub.Query(request)` had `.Response` field, so `json.loads` failed. `client_example.run()` has additional `if` condition, which prevents from this behavior, so added same check here too.

-------------------------------------

Second commit - workflow on Artifact instantiation and collection I found useful during Triage stage of single host.

I introduce function `wrappers.run_artifact()` that takes hostname and artifact name, and return results as `pandas.DataFrame`.

Examples:
```
    >>> df = wrappers.run_artifact("HOSTNAME", "Windows.System.Pslist")

    [+] Client ID found: C.869eb611eaa5b899
    [!] Running VQL:

            SELECT collect_client(
                client_id="C.869eb611eaa5b899", 
                artifacts="Windows.System.Pslist") 
            AS Flow FROM scope() 

    [+] Got artifact flow ID: F.BVSSIUHNPUV7E
    [!] Collecting data using following VQL:

            SELECT * FROM source(
                artifact='Windows.System.Pslist',
                client_id="C.869eb611eaa5b899", flow_id='F.BVSSIUHNPUV7E') 

    [!] Artifact is running... 0s
    [!] Artifact is running... 5.3s
    [+] Done! 11.0s
```

To supress output use `verbose=False`:
```
    >>> df = wrappers.run_artifact("MY_HOSTNAME", "Windows.System.Pslist", verbose=False)
```

Artifact parameters should be provided as Python dictionary:
```
    >>> params = {"ProcessRegex": "cmd"}
    >>> df = wrappers.run_artifact("HOSTNAME", "Windows.System.Pslist", artifact_parameters=params)
```

Function looks reliable - didn't found any problems in my environments. 

Few cases include where some artifacts use different strings for instantiation and collection, e.g.: `"Windows.Network.NetstatEnriched"`, VR only returns data if artifact name is specified as: `"Windows.Network.NetstatEnriched/Netstat"`:

```
netstat = run_artifact(HOSTNAME, "Windows.Network.NetstatEnriched", artifact_collect_name="Windows.Network.NetstatEnriched/Netstat")
```

Supports `limit` and `timeout` options as well.